### PR TITLE
Use the searchableAs method on the model to define the collection and bucket names

### DIFF
--- a/src/Engines/SonicSearchEngine.php
+++ b/src/Engines/SonicSearchEngine.php
@@ -2,6 +2,7 @@
 
 namespace james2doyle\SonicScout\Engines;
 
+use Illuminate\Database\Eloquent\Model;
 use Laravel\Scout\Builder;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Laravel\Scout\Engines\Engine;
@@ -78,15 +79,18 @@ class SonicSearchEngine extends Engine
 
         $this->ingest->ping();
 
-        $messages = $models->map(function ($model) {
+        $self = $this;
+
+        $messages = $models->map(function ($model) use ($self) {
             if (empty($searchableData = $model->toSearchableArray())) {
                 return;
             }
 
-            $bucket = class_basename($model);
+            $collection = $self->getCollectionFromModel($model);
+            $bucket = $self->getBucketFromModel($model);
 
             return [
-                str_plural($bucket),
+                $collection,
                 $bucket,
                 $model->getScoutKey(),
                 is_array($searchableData) ? implode(' ', array_values($searchableData)) : $searchableData,
@@ -116,9 +120,12 @@ class SonicSearchEngine extends Engine
     {
         $this->ingest->ping();
 
-        $models->map(function ($model) {
-            $bucket = class_basename($model);
-            $this->ingest->flush(str_plural($bucket), $bucket, $model->getScoutKey());
+        $self = $this;
+
+        $models->map(function ($model) use ($self) {
+            $collection = $self->getCollectionFromModel($model);
+            $bucket = $self->getBucketFromModel($model);
+            $this->ingest->flush($collection, $bucket, $model->getScoutKey());
         })->values()->all();
     }
 
@@ -135,8 +142,31 @@ class SonicSearchEngine extends Engine
     {
         $this->search->ping();
 
-        $bucket = class_basename($builder->model);
-        return $this->search->query(str_plural($bucket), $bucket, $builder->query, $limit, $offset);
+        $collection = $this->getCollectionFromModel($builder->model);
+        $bucket = $this->getBucketFromModel($builder->model);
+        return $this->search->query($collection, $bucket, $builder->query, $limit, $offset);
+    }
+
+    /**
+     * Generate the collection name based on the model
+     *
+     * @param Model $model
+     * @return string
+     */
+    private function getCollectionFromModel($model)
+    {
+        return str_plural($this->getBucketFromModel($model));
+    }
+
+    /**
+     * Generate the collection name based on the model
+     *
+     * @param Model $model
+     * @return string
+     */
+    private function getBucketFromModel($model)
+    {
+        return $model->searchableAs();
     }
 
     /**

--- a/tests/Fixtures/SearchableModel.php
+++ b/tests/Fixtures/SearchableModel.php
@@ -29,4 +29,9 @@ class SearchableModel extends Model
     {
         return [];
     }
+
+    public function searchableAs()
+    {
+        return 'SearchableModel';
+    }
 }

--- a/tests/SonicEngineTest.php
+++ b/tests/SonicEngineTest.php
@@ -208,7 +208,7 @@ class SonicEngineTest extends TestCase
             $args = func_get_args();
             $expected = [
                 str_plural($args[0]), // inject mockery class details
-                $args[1], // inject mockery class details
+                'OtherSearchableAs',
                 '1',
                 '1 hello@example.com'
             ];
@@ -227,6 +227,7 @@ class SonicEngineTest extends TestCase
         $model = Mockery::mock(stdClass::class);
         $model->shouldReceive('getScoutKey')->andReturn(1);
         $model->shouldReceive('toSearchableArray')->andReturn(['id' => 1, 'email' => 'hello@example.com']);
+        $model->shouldReceive('searchableAs')->andReturn('OtherSearchableAs');
 
         $engine = new SonicSearchEngine($factory);
         $engine->update(Collection::make([$model]));


### PR DESCRIPTION
⚠️ Slight warning/potential issue with this one

With this change, if someone is upgrading, they'd have to change the `searchableAs` method on the model to match what used to be in the library.

For example, if you have a model of `User`, we would previously have ended up with:

* Collection: `Users`
* Bucket: `User`

With this change, the defaults become:

* Collection: `users`
* Bucket: `users`

To maintain backward compatibility, the model would need to add:

```php
public function searchableAs()
{
    return 'User';
}
```

Not sure if this could just be explained with upgrade notes, or if it would warrant a major version bump being a breaking change?